### PR TITLE
Fix: set message to none once it is used

### DIFF
--- a/dchat/roles/joiner.py
+++ b/dchat/roles/joiner.py
@@ -75,6 +75,8 @@ class Joiner(Role):
                     elif message.dtype == DType.LEDGER_DADDR:
                         daddrs.append(message.msg)
 
+                    message = None
+
         for ip, nick_name, timestamp, daddr in zip(ips, nicknames, timestamps, daddrs):
             clients.add_entry(
                 LedgerEntry(


### PR DESCRIPTION
Closes #16 

**Implementation**

1. Set the message object to None once it has been used. 